### PR TITLE
Update Workshop links in geonode website

### DIFF
--- a/pages/workshops/index.html
+++ b/pages/workshops/index.html
@@ -17,21 +17,21 @@
                 <div class="span4">
                     <article class="article1">
                         <img src="../static/img/user.png" width="72" alt="" class="icon" />
-                        <h4><a href='/workshops/user/'>Users Workshop</a></h4>
+                        <h4><a href='http://docs.geonode.org/en/latest/users/index.html'>Users Workshop</a></h4>
                         <p>In the user workshop you will learn how to create an account on Geonode, add layers and maps to your account as well as publishing those.</p>
                     </article>
                 </div>
                 <div class="span4">
                     <article id="mailing-lists" class="article1">
                         <img src="../static/img/admin.png" width="72" alt="" class="icon" />
-                        <h4><a href='/workshops/admin/'>Administrators Workshop</a></h4>
+                        <h4><a href='http://docs.geonode.org/en/latest/deploy/install.html'>Administrators Workshop</a></h4>
                         <p>The administrator workshop will guide you through the installation and configuration of Geonode, as well as explore further possibilities with Geonode.</p>
                     </article>
                 </div>
                 <div class="span4">
                     <article id="irc" class="article1">
                         <img src="../static/img/dev.png" width="72" alt="" class="icon" />
-                        <h4><a href='/workshops/devel/'>Developers Workshop</a></h4>
+                        <h4><a href='http://docs.geonode.org/en/latest/developers/setup.html'>Developers Workshop</a></h4>
                         <p>The developers workshop will show you how to set up your own Genode project, start developing, customizing, integrating, bug fixing etc.</p>
                     </article>
                 </div>


### PR DESCRIPTION
Related to issue: https://github.com/GeoNode/geonode/issues/1116
Under Workshops, fixed User workshop, Developers workshop and Administrators workshop links 
