### PR TITLE
Fix FAQs link on front page

### DIFF
--- a/_includes/important_links.html
+++ b/_includes/important_links.html
@@ -75,7 +75,7 @@
           <div class="col-md-6">
             <div class="col-md-12">
             <i class="fa fa-question-circle fa-5x col-md-2"></i>
-              <a class="col-md-10" href="{{site.baseurl}}/faqs.html">
+              <a class="col-md-10" href="{{site.baseurl}}/faqs">
                 <article class="faqs">
                   <h3>FAQs</h3>
                   <p>Frequently Asked Questions about GeoNode</p>


### PR DESCRIPTION
In the GeoNode.org front page footer, change link target for "FAQs"
from `faqs.html` to just `faqs`, following up to commit f4793f8.