### PR TITLE
jobs board and other fixes

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,14 +21,16 @@
             <li><a href="http://docs.geonode.org" target = "_blank">Documentation</a></li>
             <li><a href="http://github.com/geonode/geonode/issues" target = "_blank">Issue Tracker</a></li>
             <li><a href="{{ site.baseurl }}/providers/">Commercial Providers</a></li>
+            <li><a href="{{ site.baseurl }}/jobs/">Jobs</a></li>
           </ul>
         </div>
       </div>
       <div class="col-md-7 col-lg-8 col-sm-7">
         <div class="pull-right">
-          <a href="{{ site.baseurl }}/#install" class="btn btn-success">Install GeoNode</a>
+          <a href="{{ site.baseurl }}/gallery" class="btn btn-success">Gallery</a>
+          <a href="{{ site.baseurl }}/#install" class="btn btn-success">Quick Start</a>
           <a target="_blank" href="http://demo.geonode.org" class="btn btn-warning">Try the Demo</a>
-          <a href="{{ site.baseurl }}/blog/" class="btn btn-success">Read our Blog</a>
+          <a href="{{ site.baseurl }}/blog/" class="btn btn-success">Blog</a>
         </div>
       </div>
     </div>

--- a/blog/_posts/2016-03-28-geonode-spring-2016-code-sprint.html
+++ b/blog/_posts/2016-03-28-geonode-spring-2016-code-sprint.html
@@ -1,12 +1,13 @@
 ---
 layout: base
+category: blog
 title: GeoNode Spring 2016 Code Sprint
 ---
 <section class="feature-detail">
   <div class="container">
     <div class="row">
       <div class="span7">
-        <h2>{{ page.title }}</h2> 
+        <h2>{{ page.title }}</h2>
         <article class="article1">
           <p>Join the GeoNode code sprint from 4 - 8 April 2016 in New Orleans, LA, USA.</p>
           <p>The code sprint will kick into action Tuesday with work on specific projects, modules, bug fixing, docs, and website.</p>

--- a/blog/_posts/2016-08-09-geonode-summer-2016-code-sprint.html
+++ b/blog/_posts/2016-08-09-geonode-summer-2016-code-sprint.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+category: blog
 title: GeoNode Summer 2016 Code Sprint
 ---
 <section class="feature-detail">

--- a/blog/_posts/2016-09-06-geonode-2016-summit.html
+++ b/blog/_posts/2016-09-06-geonode-2016-summit.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+category: blog
 title: GeoNode Summit 2016
 ---
 <section class="feature-detail">

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -2,19 +2,13 @@
 layout: base
 title: Gallery - GeoNode
 body_class: "geonode-features sites-gallery"
----    
+---
 <section class="banner">
   <div class="container">
     <div class="row">
-      <div class="span6">
-        <h1>
-          <strong>Hello</strong>,<br />
-          <span>Welcome to the <strong>GeoNode</strong> Gallery</span>
-        </h1>
-
-      </div>
-      <div class="span6">
-        <img src="{{site.baseurl}}/static/img/features_hero_img.png" width="489" height="216" alt="" class="pull-right hero-img" />
+      <div class="span12">
+        <h3>Welcome to the GeoNode gallery!</h3>
+        <h4>Below are instances of GeoNode being used for achieving success across a wide variety of missions, including humanitarian, development, and environmental.</h4>
       </div>
     </div>
   </div>
@@ -492,7 +486,7 @@ body_class: "geonode-features sites-gallery"
           <h4>Geobeyond</h4>
           <div>
             <p>
-              GeoAvalanche is a spatial data infrastructure for sharing snow avalanche information and maps with standards in mind. The project supports the development of geospatial solutions to allow the exchange of data between avalanche warning services, authorities and the public for publishing more reliable avalanche risk maps.  
+              GeoAvalanche is a spatial data infrastructure for sharing snow avalanche information and maps with standards in mind. The project supports the development of geospatial solutions to allow the exchange of data between avalanche warning services, authorities and the public for publishing more reliable avalanche risk maps.
             </p>
 
             <p>
@@ -502,10 +496,10 @@ body_class: "geonode-features sites-gallery"
           </div>
         </div>
       </div>
-      
+
    </div>
  </div>
-</section>        
+</section>
 
 <section class="feature-details feature2" id="worldwide">
   <div class="container">
@@ -554,7 +548,7 @@ body_class: "geonode-features sites-gallery"
           <h4>Agricultural Web Atlas for REsearch</h4>
           <div>
             <p>
-              In Reunion Island the CIRAD (French Agricultural Research Centre for International Development) needed a platform to collect geographic data in order to share spatial data, facilitate access by its teams, and better communicate research results. 
+              In Reunion Island the CIRAD (French Agricultural Research Centre for International Development) needed a platform to collect geographic data in order to share spatial data, facilitate access by its teams, and better communicate research results.
               Using GeoNode, AWARE (Agricultural Web Atlas for REsearch) meets these needs by providing a catalog of geospatial data available at CIRAD in Reunion Island. The atlas is based on a profile management to respect the rules of confidentiality and broadcasting rights.
               AWARE targets a wide audience : researchers, agricultural professionals, teachers, funders... Its strength lies in its ability to share spatial information through some said users 'contributors' who can add layers, create maps without using GIS software. It is also possible to link documents to layers and maps. Finally, the atlas uses free technology solutions that implement OGC standards (WMS, WCS, WFS and OWS) ensuring interoperability with GIS software such as ArcGIS or QGIS.
             </p>
@@ -566,10 +560,10 @@ body_class: "geonode-features sites-gallery"
           </div>
         </div>
       </div>
-      
+
    </div>
  </div>
-</section>   
+</section>
 
 <section class="feature-details feature2" id="americas">
   <div class="container">
@@ -581,7 +575,7 @@ body_class: "geonode-features sites-gallery"
           <h4>Government of Saint Lucia</h4>
           <div>
             <p>
-              SLING (Saint Lucia Integrated GeoNode) is a spatial data sharing portal operated by the Surveys and Mapping Section of the Government of Saint Lucia. 
+              SLING (Saint Lucia Integrated GeoNode) is a spatial data sharing portal operated by the Surveys and Mapping Section of the Government of Saint Lucia.
             </p>
 
             <p>
@@ -592,7 +586,7 @@ body_class: "geonode-features sites-gallery"
         </div>
 
       </div>
-     
+
    </div>
  </div>
 </section>
@@ -609,7 +603,7 @@ body_class: "geonode-features sites-gallery"
           <h4>Government of Dominica</h4>
           <div>
             <p>
-              Dominode is a geospatial data sharing portal operated by the Government of the Commonwealth of Dominica. 
+              Dominode is a geospatial data sharing portal operated by the Government of the Commonwealth of Dominica.
             </p>
 
             <p>
@@ -619,9 +613,9 @@ body_class: "geonode-features sites-gallery"
           </div>
         </div>
       </div>
-      
+
    </div>
  </div>
-</section> 
+</section>
 
 {% include footer.html %}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@ title: GeoNode
           </p>
           <div class="promo-links">
             <a title="OSGeo Project in Incubation" href="http://osgeo.org"><img style="background-color:white;" alt="OSGeo Project in Incubation" src="https://svn.osgeo.org/osgeo/marketing/logo/png8/150/OSGeo_incubation.png"/></a>
-            <a title="FOSS4G Conference" href="http://2016.foss4g.org"><img style="background-color:white;" alt="FOSS4G Conference" src="https://svn.osgeo.org/osgeo/foss4g/2016/marketing/logo/foss4g-logo_150x45px.png"/></a>
           </div>
         </div>
         <div class="col-md-6 col-lg-6 col-sm-6 col-xs-6">
@@ -87,27 +86,6 @@ title: GeoNode
           <a href = "{{ site.baseurl }}/admin_features" class="btn btn-success">Take the Tour</a>
         </div>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="blog-posts">
-  <div class="container">
-    <div class="row">
-      {% for post in site.posts limit:2 %}
-       <div class="post-preview col-md-5">
-         <div class="col-md-6">
-           <img src="{{ post.image }}">
-         </div>
-         <div class="col-md-6">
-           <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
-            <span class="post-date">{{ post.date | date: "%B %d, %Y" }}</span>
-            {% if post.content contains '<!--break-->' %}
-              <a href="{{ site.baseurl }}{{ post.url }}">read more</a>
-           {% endif %}
-        </div>
-       </div>
-      {% endfor %}
     </div>
   </div>
 </section>

--- a/jobs/_posts/2016-12-13-geosolutions-python-dev.md
+++ b/jobs/_posts/2016-12-13-geosolutions-python-dev.md
@@ -1,0 +1,20 @@
+---
+layout: base
+category: jobs
+title: Python Web Developer (Django/Flask)
+organization:
+  title: GeoSolutions
+  url: "http://www.geo-solutions.it"
+duties: []
+requirements:
+  - "1+ years of experience in Software Engineering."
+  - "Good knowledge of Python and the Django and/or Flask Web Framework."
+benefits:
+  remote: true
+link: "http://www.geo-solutions.it/jobs/python-web-developer/"
+tags: []
+---
+
+GeoSolutions is looking for a Python Web Developer (Django/Flask) to work on back-end and front-end geospatial applications (including GeoNode).
+
+This is a role that will grow significantly with the business.

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,0 +1,45 @@
+---
+layout: base
+title: Jobs - GeoNode
+body_class: "geonode-features"
+---
+
+<style>
+
+.jobs li{
+  list-style: none;
+  margin-top: 20px;
+  margin-left: 10px;
+}
+.jobs h1 {
+  margin-top: 20px;
+}
+</style>
+
+<section class="feature-detail">
+ <div class="container">
+   <div class="row">
+    <div class="span12">
+      <ul class="jobs">
+        {% for post in site.categories.jobs %}
+        <li>
+          <h3><a target="_blank" href="{{ post.link }}">{{ post.title }}</a></h3>
+          <h4>Organization:</h4>
+          <h5><a target="_blank" href="{{ post.organization.url }}">{{ post.organization.title }}</a></h5>
+          <h4>Description:</h4>
+          {{ post.content | markdownify }}
+          <h4>Requirements (more in post):</h4>
+          {% for requirement in post.requirements %}
+          <h5>- {{ requirement }}</h5>
+          {% endfor %}
+          <h4><a target="_blank" href="{{ post.link }}">View Post</a></h4>
+          <hr>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+</section>
+
+{% include footer.html %}


### PR DESCRIPTION
Adds a Jobs boards at http://geonode.org/jobs and other fixes, including:

- Adjust header (adds link to gallery)
- Shrink banner on Gallery page (actual content should be "above the fold")
- remove link to FOSS4G 2016
- removed blog tiles from homepage (moves quickstart up the page)
- other minor fixes