### PR TITLE
Fix documentation base link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ ga:
   code: "UA-38570723-1"
 
 extbase:
-  docs: "https://docs.geonode.org/en/3.1/"
+  docs: "https://docs.geonode.org/en/master/"
 
 
 dns_prefetch: ['//www.google-analytics.com', '//fonts.googleapis.com']


### PR DESCRIPTION
Change RTD base link to master, current version of 3.1 does not exist (anymore?) and breaks FAQ entries.

If you want to keep tracking 3 instead, change `3.1` to `3.x`. (although `master` is linked elsewhere, e.g. documentation link in the dropdown)