### PR TITLE
Fix missing github image on website

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -41,7 +41,7 @@ layout: blank
   <body class="{{ page.body_class }}">
     {% include header.html %}
     {{ content }}
-    <a href="https://github.com/GeoNode/geonode/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/GeoNode/geonode/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
     <script type="text/javascript" src="{{site.baseurl}}/static/js/jquery-3.6.0.min.js"></script>
     <script type="text/javascript" src="{{site.baseurl}}/static/js/sequence.jquery-min.js"></script>
     <script type="text/javascript" src="{{site.baseurl}}/static/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The imagelink is visible on this code snippets:

https://github.blog/2008-12-19-github-ribbons/